### PR TITLE
Replace pprint with logger

### DIFF
--- a/aiogram_inline_paginations/paginator.py
+++ b/aiogram_inline_paginations/paginator.py
@@ -1,5 +1,6 @@
 from itertools import islice
-from pprint import pprint
+from logging import getLogger
+from pprint import pformat
 from typing import Iterable, Any, Iterator, Callable, Coroutine, Tuple
 
 from aiogram import types, Dispatcher, Router
@@ -8,6 +9,8 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State
 from aiogram.types import CallbackQuery
 from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+logger = getLogger(__name__)
 
 
 class Paginator:
@@ -90,9 +93,7 @@ class Paginator:
             page_separator=self.page_separator,
             startswith=self._startswith
         )
-        pprint(
-            [*_list_current_page, paginations]
-        )
+        logger.debug("\n%s", pformat([*_list_current_page, paginations], indent=1, width=1))
         keyboard = types.InlineKeyboardMarkup(inline_keyboard=[*_list_current_page, paginations])
 
         # keyboard.add(_list_current_page)


### PR DESCRIPTION
Заменил `pprint` на `logger`, чтобы вывод консоли не засорять.
Теперь чтобы увидеть вывод достаточно перевести логгер пагинатора в режим дебага

Например так
```python
import logging

logging.getLogger("aiogram_inline_paginations.paginator").setLevel("DEBUG")
```

P.S. формат вывода остался прежним